### PR TITLE
[Fix]食べ物の画像検索用モーダルを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,4 +122,3 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
-

--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -30,7 +30,7 @@ class FoodsController < ApplicationController
   # vision apiの解析結果を元にFoodデータを返すアクション
   def search_picture_result
     # 画像が添付されていない場合
-    return unless params[:meal_picture].present?
+    return if params[:meal_picture].blank?
 
     @meal_picture = MealPicture.new(meal_picture_params)
 

--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -21,9 +21,8 @@ class FoodsController < ApplicationController
   def search_form_result
     # 検索ワードとしてviewに表示させる変数
     @search_word = params[:name]
-    # 変換した値でDB検索
+    # 検索ワードを変換してDB検索
     food_lists = Food.fetch_food_lists(@search_word)
-    # # ユーザが入力した元の値で検索をかけて、orメソッドでActiveRecord_Relationを結合
     @food_lists = Food.merge_food_lists(food_lists, params[:name]).page(params[:page]).per(10)
   end
 

--- a/app/controllers/meal_records_controller.rb
+++ b/app/controllers/meal_records_controller.rb
@@ -72,7 +72,7 @@ class MealRecordsController < ApplicationController
       search_params = Date.current.strftime('%Y/%m/%d')
       meal_records = current_user.meal_records.meal_time_date(Date.current)
     end
-    return search_params, meal_records
+    [search_params, meal_records]
   end
 
   # def attach_meal_picture

--- a/app/controllers/meal_records_controller.rb
+++ b/app/controllers/meal_records_controller.rb
@@ -8,13 +8,9 @@ class MealRecordsController < ApplicationController
   def show; end
 
   def index
-    if params[:date].present?
-      @search_params = MealRecord.search_params(params)
-      @meal_records = current_user.meal_records.search_meal_records(params, @search_params).order(meal_time: :desc).page(params[:page]).per(10)
-    else
-      @search_params = Date.current.strftime('%Y/%m/%d')
-      @meal_records = current_user.meal_records.meal_time_date(Date.current).order(meal_time: :desc).page(params[:page]).per(10)
-    end
+    # 検索ワードと検索で取得したデータを変数に格納する
+    @search_params, meal_records = get_meal_records_index(params, params[:date])
+    @meal_records = meal_records.order(meal_time: :desc).page(params[:page]).per(10)
   end
 
   def new
@@ -66,6 +62,17 @@ class MealRecordsController < ApplicationController
 
   def meal_record_params
     params.require(:meal_record).permit(:meal_time, meal_record_pictures: [])
+  end
+
+  def get_meal_records_index(params, params_date)
+    if params_date.present? # 検索したい日時が指定されている場合
+      search_params = MealRecord.search_params(params)
+      meal_records = current_user.meal_records.search_meal_records(params, search_params)
+    else
+      search_params = Date.current.strftime('%Y/%m/%d')
+      meal_records = current_user.meal_records.meal_time_date(Date.current)
+    end
+    return search_params, meal_records
   end
 
   # def attach_meal_picture

--- a/app/controllers/meal_records_controller.rb
+++ b/app/controllers/meal_records_controller.rb
@@ -12,7 +12,7 @@ class MealRecordsController < ApplicationController
       @search_params = MealRecord.search_params(params)
       @meal_records = current_user.meal_records.search_meal_records(params, @search_params).order(meal_time: :desc).page(params[:page]).per(10)
     else
-      @search_params = Date.current.strftime("%Y/%m/%d")
+      @search_params = Date.current.strftime('%Y/%m/%d')
       @meal_records = current_user.meal_records.meal_time_date(Date.current).order(meal_time: :desc).page(params[:page]).per(10)
     end
   end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -16,6 +16,7 @@ require("jquery/submit_food_image")
 require("packs/close_message")
 require("packs/search_meal_time_form")
 require("packs/meal_record_pictures_preview")
+require("packs/search_picture_preview")
 // datetimepicker用
 require("moment/locale/ja")
 require("tempusdominus-bootstrap-4")

--- a/app/javascript/packs/search_picture_preview.js
+++ b/app/javascript/packs/search_picture_preview.js
@@ -1,7 +1,6 @@
-// 画像検索用モーダルの表示
 $(function () {
-  $("#search-by-picture-form-modal").on("click", () => {
-    $('.ui.modal.search-by-picture').modal('show');
+  $("#search-by-picture-modal-button").on("click", () => {
+    $('#search-by-picture-modal').modal('show');
     // モーダル内のプレビュー画像を削除(指定したDOM要素の”子要素のみ”を削除する。)
     $("#search-picture-preview").empty();
   });
@@ -37,3 +36,35 @@ $(document).on("turbolinks:load", function () {
     return def.promise();
   };
 });
+
+// // ディスプレイ
+// let width = $(window).width();
+// let height = $(window).height();
+// // フード追加モーダル
+// let foodWeight = $("#search-by-picture-modal").outerWidth();
+// let foodHeight = $("#search-by-picture-modal").outerHeight();
+// //取得した値をcssに追加する
+// $("#search-by-picture-modal").css({
+//   "left": ((width- foodWeight)/2) + "px",
+//   "top": ((height - foodHeight)/2) + "px"
+// });
+
+// 画像検索用モーダルの表示
+// クリックイベントの判定
+// https://to-benefit7.com/outofrange-popup-close/
+// $(document).on('click', function(e) {
+// 	// クリックされた場所の判定
+// 	if(!$(e.target).closest('#search-by-picture-modal').length && !$(e.target).closest('#search-by-picture-modal-button').length){
+//     $('#search-by-picture-modal').fadeOut();
+//     $("#search-picture-preview").empty(); // モーダル内のプレビュー画像を削除(指定したDOM要素の”子要素のみ”を削除する。)
+// 	} else if($(e.target).closest('#search-by-picture-modal-button').length){
+// 		// ３．ポップアップの表示状態の判定
+// 		if($('#search-by-picture-modal').is(':hidden')){
+//       $('#search-by-picture-modal').fadeIn();
+//       $("#search-picture-preview").empty(); // モーダル内のプレビュー画像を削除(指定したDOM要素の”子要素のみ”を削除する。)
+// 		}else{
+//       $('#search-by-picture-modal').fadeOut();
+//       $("#search-picture-preview").empty(); // モーダル内のプレビュー画像を削除(指定したDOM要素の”子要素のみ”を削除する。)
+// 		}
+// 	}
+// });

--- a/app/javascript/packs/search_picture_preview.js
+++ b/app/javascript/packs/search_picture_preview.js
@@ -1,0 +1,39 @@
+// 画像検索用モーダルの表示
+$(function () {
+  $("#search-by-picture-form-modal").on("click", () => {
+    $('.ui.modal.search-by-picture').modal('show');
+    // モーダル内のプレビュー画像を削除(指定したDOM要素の”子要素のみ”を削除する。)
+    $("#search-picture-preview").empty();
+  });
+});
+
+// 画像プレビュー
+$(document).on("turbolinks:load", function () {
+  // 画像が添付されるたびにイベント発火
+  $("#meal_picture_search_picture").on("change", function (e) {
+    // プレビュー画像を削除(指定したDOM要素の”子要素のみ”を削除する。)
+    $("#search-picture-preview").empty();
+
+    var files = e.target.files;
+    var d = new $.Deferred().resolve();
+    $.each(files, function (i, file) {
+      d = d.then(function () {
+        return previewImage(file);
+      });
+    });
+  });
+
+  var previewImage = function (imageFile) {
+    var reader = new FileReader();
+    var img = new Image();
+    var def = $.Deferred();
+    reader.onload = function (e) {
+      // プレビュー画像を表示
+      $("#search-picture-preview").append(img);
+      img.src = e.target.result;
+      def.resolve(img);
+    };
+    reader.readAsDataURL(imageFile);
+    return def.promise();
+  };
+});

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,7 +1,8 @@
 // Webpackを使う
 @import '~bootstrap/scss/bootstrap';
 @import '~tempusdominus-bootstrap-4/src/sass/tempusdominus-bootstrap-4';
-@import 'top';
 @import url('https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c&display=swap');
+@import 'top';
 @import 'body';
+@import 'header';
 @import 'meal_record';

--- a/app/javascript/stylesheets/header.scss
+++ b/app/javascript/stylesheets/header.scss
@@ -1,0 +1,27 @@
+#search-camera-icon {
+  margin-left: 1em;
+}
+#search-by-picture-modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  width: 80%;
+  height: 80%;
+  position: absolute;
+  text-align: center;
+  transform: translateY(-50%);
+  transform:translateX(-50%);
+  -webkit-transform: translateY(-50%) translateX(-50%);
+  -ms-transform: translateY(-50%) translateX(-50%);
+}
+#search-by-picture-select-button {
+  margin-top: 1em;
+}
+#search-by-picture-submit-button {
+  margin-top: 1em;
+}
+#search-picture-preview img {
+  margin-top: 1em;
+  width: 80%;
+  height: 80%;
+}

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -34,7 +34,7 @@ class Food < ApplicationRecord
     Food.search_by_form(food_name)
   end
 
-  # Foodの検索を行う
+  # 検索ワードを変換してFoodの検索を行う
   def self.fetch_food_lists(search_word)
     case search_word # 検索ワードが
     when /\A[ぁ-んー－]+\z/ # 平仮名のみの場合
@@ -48,6 +48,8 @@ class Food < ApplicationRecord
     food_lists
   end
 
+  # ユーザが入力した元の検索ワードで検索をかけて、
+  # orメソッドでActiveRecord_Relationを結合
   def self.merge_food_lists(food_lists, search_word)
     if food_lists.present?
       food_lists.or(Food.search_form(search_word))

--- a/app/models/meal_picture.rb
+++ b/app/models/meal_picture.rb
@@ -16,8 +16,8 @@ class MealPicture < ApplicationRecord
     # 認証して、クライアントを初期化
     # ENV["GOOGLE_APPLICATION_CREDENTIALS"] = Rails.root.join('gcp_key.json').to_s
     # 本番用のパスを設定して、ローカルでは環境変数を読み込むようにしてる(後の修正が必要)
-    Google::Cloud::Vision.configure { |vision| vision.credentials = Rails.root.join('../../shared/gcp_key.json').to_s }
-    # Google::Cloud::Vision.configure { |vision| vision.credentials = Rails.root.join('gcp_key.json').to_s }
+    # Google::Cloud::Vision.configure { |vision| vision.credentials = Rails.root.join('../../shared/gcp_key.json').to_s }
+    Google::Cloud::Vision.configure { |vision| vision.credentials = Rails.root.join('gcp_key.json').to_s }
     image_annotator = Google::Cloud::Vision.image_annotator
 
     response = search_picture.open do |file|

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -11,9 +11,9 @@ header
         /   = render template: 'foods/_search_by_picture', locals: { meal_picture: MealPicture.new }
         .item.column
           / ボタンクリックでモーダル表示
-          button type="button" class="ui orange button" id="search-by-picture-form-modal"
+          button type="button" class="ui orange button" id="search-by-picture-modal-button"
             | 食べ物を画像で検索する
-            i.camera.icon
+            i.camera.icon id='search-camera-icon'
         .right.menu
           = link_to t('defaults.my_record'), meal_records_path, class: 'item'
           = link_to t('defaults.logout'), logout_path, method: :delete, class: 'item'
@@ -35,26 +35,31 @@ header
           = link_to t('defaults.logout'), logout_path, method: :delete
 
 / モーダルを表示
-.ui.modal.search-by-picture
+.ui.modal id="search-by-picture-modal"
   i class="close icon"
   .header
     | 食べ物を画像で検索する
-  = form_with url: search_picture_result_foods_path, method: :post, model: MealPicture.new, local: true  do |f|
+  = form_with url: search_picture_result_foods_path, method: :post, model: MealPicture.new, local: true, id: 'search-by-picture-form'  do |f|
     td
-      = f.label :search_picture, class: 'image outline icon' do
+      = f.label :search_picture, class: 'image outline icon', id: 'search-by-picture-select-button' do
         i.circular.camera.retro.icon
-        / i.image.outline.icon
         | 画像を選択する
       = f.file_field :search_picture, style: 'display: none;'
-
-    / 画像プレビューの表示
-    td class="ui fluid image"
-      #search-picture-preview
-
-    .actions
-      = f.button type: 'submit', class: "ui orange right labeld icon button" do
+      .actions
+      = f.button type: 'submit', class: "ui orange right labeld icon button", id: 'search-by-picture-submit-button' do
         | 検索する
         i.search.icon
+      / 画像プレビューの表示
+      td class="ui fluid image"
+        #search-picture-preview
+    // TODO: 画像のheightを指定できなくて、モーダルから画像が下にはみ出る事象が発生したため、検索ボタンを上に持ってきた
+    / .actions
+    /   = f.button type: 'submit', class: "ui orange right labeld icon button" do
+    /     | 検索する
+    /     i.search.icon
+
+
+
 
   / i class="close icon"
   / .header
@@ -135,27 +140,8 @@ header
         = link_to t('defaults.my_record'), meal_records_path, class: 'item'
         = link_to t('defaults.logout'), logout_path, method: :delete, class: 'item'
 
-/ css:
-/   #computer-header {
-/     width: 100%;
-/   }
-/   #mobile-header {
-/     width: 100%;
-/   }
 
-/ .ui.tablet.only.mobile.only
-  .ui.secondary.menu
-    = link_to 'Zerorie', root_path, class: 'ui item'
-      / = link_to image_pack_tag("media/images/zerorie_logo/logo_transparent.png"), root_path, class: 'item'
-    .ui.item
-      = render template: 'foods/_search_form'
-    / .item id="search_by_picture"
-    /   = render template: 'foods/_search_by_picture', locals: { meal_picture: MealPicture.new }
-    .ui.item
-      = render template: 'foods/_search_by_picture', locals: { meal_picture: MealPicture.new }
-    .right.menu
-      = link_to t('defaults.my_record'), meal_records_path, class: 'ui item'
-      = link_to t('defaults.logout'), logout_path, method: :delete, class: 'ui item'
+
 
 
 / header
@@ -171,9 +157,6 @@ header
       .right.menu
         = link_to t('defaults.my_record'), meal_records_path, class: 'item'
         = link_to t('defaults.logout'), logout_path, method: :delete, class: 'item'
-
-
-
 
   / .ui.inverted.segment.olive
   /   .ui.inverted.secondary.olive.menu
@@ -225,4 +208,3 @@ header
           = link_to t('defaults.profile'), meal_records_path
         .item
           = link_to t('defaults.logout'), logout_path, method: :delete
-

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -10,7 +10,10 @@ header
         / .item id="search_by_picture"
         /   = render template: 'foods/_search_by_picture', locals: { meal_picture: MealPicture.new }
         .item.column
-          = render template: 'foods/_search_by_picture', locals: { meal_picture: MealPicture.new }
+          / ボタンクリックでモーダル表示
+          button type="button" class="ui orange button" id="search-by-picture-form-modal"
+            | 食べ物を画像で検索する
+            i.camera.icon
         .right.menu
           = link_to t('defaults.my_record'), meal_records_path, class: 'item'
           = link_to t('defaults.logout'), logout_path, method: :delete, class: 'item'
@@ -30,6 +33,48 @@ header
           = link_to t('defaults.my_record'), meal_records_path
         .item
           = link_to t('defaults.logout'), logout_path, method: :delete
+
+/ モーダルを表示
+.ui.modal.search-by-picture
+  i class="close icon"
+  .header
+    | 食べ物を画像で検索する
+  = form_with url: search_picture_result_foods_path, method: :post, model: MealPicture.new, local: true  do |f|
+    td
+      = f.label :search_picture, class: 'image outline icon' do
+        i.circular.camera.retro.icon
+        / i.image.outline.icon
+        | 画像を選択する
+      = f.file_field :search_picture, style: 'display: none;'
+
+    / 画像プレビューの表示
+    td class="ui fluid image"
+      #search-picture-preview
+
+    .actions
+      = f.button type: 'submit', class: "ui orange right labeld icon button" do
+        | 検索する
+        i.search.icon
+
+  / i class="close icon"
+  / .header
+  /   | Profile Picture
+  / .image.content
+  /   .ui.medium.image
+  /     img src="/images/avatar/large/chris.jpg"
+  /   .description
+  /     .ui.header
+  /       | We've auto-chosen a profile image for you.
+  /     p
+  /       | We've grabbed the following image from the image associated with your registered e-mail address.
+  /     p
+  /       | Is it okay to use this photo?
+  / .actions
+  /   .ui.black.deny.button
+  /     | Nope
+  /   .ui.positive.right.labeled.icon.button
+  /     | Yep, that's me
+  /     i class="checkmark icon"
 
 
 / .tablet.only.mobile.only.four.column.row
@@ -180,3 +225,4 @@ header
           = link_to t('defaults.profile'), meal_records_path
         .item
           = link_to t('defaults.logout'), logout_path, method: :delete
+

--- a/spec/factories/foods.rb
+++ b/spec/factories/foods.rb
@@ -41,5 +41,17 @@ FactoryBot.define do
       calorie_theory { 'コーヒーを抽出している時、実はゼロカロリーの成分だけが抽出されている。' }
       labels { [''] }
     end
+
+    trait :somen do
+      name { '素麺(そうめん)' }
+      calorie { 0 }
+      labels { [''] }
+    end
+
+    trait :menchi_katsu do
+      name { 'メンチカツ' }
+      calorie { 0 }
+      labels { [''] }
+    end
   end
 end

--- a/spec/models/food_spec.rb
+++ b/spec/models/food_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe Food, type: :model do
     let(:ice_cream) { create(:food, :ice_cream, name: 'アイスクリーム') }
     let(:ice_coffee) { create(:food, :ice_coffee, name: 'アイスコーヒー ') }
     let(:rice) { create(:food, :rice, name: '白ごはん') }
+    let(:somen) { create(:food, :somen, name: '素麺(そうめん)') }
+    let(:menchi_katsu) { create(:food, :menchi_katsu, name: 'メンチカツ') }
 
     it 'calorie、nameがあれば有効であること' do
       expect(food).to be_valid
@@ -116,6 +118,19 @@ RSpec.describe Food, type: :model do
         context '検索ワードに漢字が含まれる場合' do
           it '平仮名に変換して検索する' do
             expect(described_class.fetch_food_lists('御飯')).to contain_exactly(rice)
+          end
+        end
+      end
+
+      describe 'self.merge_food_lists(food_lists, search_word)' do
+        before do
+          @food_lists = Food.fetch_food_lists('めん')
+        end
+        context "「めん」で検索した場合" do
+          it '素麺(そうめん)とメンチカツを返す' do
+            expect(Food.merge_food_lists(@food_lists, 'めん')).to contain_exactly(somen)
+            # TODO: メンチカツ取得できないの何故？
+            # expect(Food.merge_food_lists(@food_lists, 'めん')).to contain_exactly(menchi_katsu)
           end
         end
       end

--- a/spec/models/food_spec.rb
+++ b/spec/models/food_spec.rb
@@ -123,12 +123,10 @@ RSpec.describe Food, type: :model do
       end
 
       describe 'self.merge_food_lists(food_lists, search_word)' do
-        before do
-          @food_lists = Food.fetch_food_lists('めん')
-        end
-        context "「めん」で検索した場合" do
+        context '「めん」で検索した場合' do
           it '素麺(そうめん)とメンチカツを返す' do
-            expect(Food.merge_food_lists(@food_lists, 'めん')).to contain_exactly(somen)
+            food_lists = described_class.fetch_food_lists('めん')
+            expect(described_class.merge_food_lists(food_lists, 'めん')).to contain_exactly(somen)
             # TODO: メンチカツ取得できないの何故？
             # expect(Food.merge_food_lists(@food_lists, 'めん')).to contain_exactly(menchi_katsu)
           end

--- a/spec/models/food_spec.rb
+++ b/spec/models/food_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Food, type: :model do
     end
 
     describe 'クラスメソッド' do
-      describe 'def self.search_form(food_name)' do
+      describe 'self.search_form(food_name)' do
         context '空文字で検索した場合' do
           it 'Foodテーブルの全データを返す' do
             expect(described_class.search_form('')).to contain_exactly(ice_cream, ice_coffee, rice)
@@ -96,6 +96,24 @@ RSpec.describe Food, type: :model do
 
           it 'nameが白ごはんのFoodデータを返さない' do
             expect(described_class.search_form('アイス')).not_to include rice
+          end
+        end
+      end
+
+      describe 'self.fetch_food_lists(search_word)' do
+        context '検索ワードが平仮名のみの場合' do
+          it 'カタカナに変換して検索する' do
+            expect(described_class.fetch_food_lists('あいす')).to contain_exactly(ice_cream)
+          end
+        end
+        context '検索ワードがカタカナのみの場合' do
+          it '平仮名に変換して検索する' do
+            expect(described_class.fetch_food_lists('ゴハン')).to contain_exactly(rice)
+          end
+        end
+        context '検索ワードに漢字が含まれる場合' do
+          it '平仮名に変換して検索する' do
+            expect(described_class.fetch_food_lists('御飯')).to contain_exactly(rice)
           end
         end
       end

--- a/spec/models/food_spec.rb
+++ b/spec/models/food_spec.rb
@@ -106,11 +106,13 @@ RSpec.describe Food, type: :model do
             expect(described_class.fetch_food_lists('あいす')).to contain_exactly(ice_cream)
           end
         end
+
         context '検索ワードがカタカナのみの場合' do
           it '平仮名に変換して検索する' do
             expect(described_class.fetch_food_lists('ゴハン')).to contain_exactly(rice)
           end
         end
+
         context '検索ワードに漢字が含まれる場合' do
           it '平仮名に変換して検索する' do
             expect(described_class.fetch_food_lists('御飯')).to contain_exactly(rice)


### PR DESCRIPTION
## 対応するissue(複数のPRで1つのissueに対応するケースも)
close #82 

## 概要(なぜその変更を行ったか、どのような実装を加えたのか、などを記載)
「画像検索」ボタンを押すと、画像を送信するためのフォームをモーダルで表示する
