### PR TITLE
Feature/35 cloud front settings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,14 +29,12 @@ gem 'mini_racer', platforms: :ruby
 gem 'sorcery'
 # S3に必要
 gem 'aws-sdk-s3', require: false
-
 # Use Active Storage variant
 gem 'image_processing', '~> 1.2'
 # GCP
 # ggsいらないのでは
 # gem 'google-cloud-storage', '~> 1.8', require: false
 gem 'google-cloud-vision'
-
 # UI/UX
 gem 'bootstrap-sass'
 # semantic UI Framework
@@ -59,6 +57,11 @@ gem 'miyabi'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
+
+group :production do
+  gem 'asset_sync'
+  gem 'fog-aws'
+end
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,11 @@ GEM
     annotate (3.1.1)
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 14.0)
+    asset_sync (2.12.1)
+      activemodel (>= 4.1.0)
+      fog-core
+      mime-types (>= 2.99)
+      unf
     ast (2.4.1)
     autoprefixer-rails (9.8.6.2)
       execjs
@@ -193,6 +198,7 @@ GEM
     exception_notification (4.4.3)
       actionmailer (>= 4.0, < 7)
       activesupport (>= 4.0, < 7)
+    excon (0.76.0)
     execjs (2.7.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
@@ -202,6 +208,23 @@ GEM
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.13.1)
+    fog-aws (3.6.7)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.2.3)
+      builder
+      excon (~> 0.71)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (0.2.5)
     gapic-common (0.3.2)
       google-protobuf (~> 3.12, >= 3.12.2)
       googleapis-common-protos (>= 1.3.9, < 2.0)
@@ -253,6 +276,7 @@ GEM
     image_processing (1.11.0)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
+    ipaddress (0.8.3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     jmespath (1.4.0)
@@ -541,6 +565,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate
+  asset_sync
   aws-sdk-s3
   bcrypt_pbkdf
   better_errors
@@ -563,6 +588,7 @@ DEPENDENCIES
   ed25519
   exception_notification
   factory_bot_rails
+  fog-aws
   google-cloud-vision
   html2slim
   image_processing (~> 1.2)

--- a/app/javascript/stylesheets/top.scss
+++ b/app/javascript/stylesheets/top.scss
@@ -7,3 +7,7 @@
 #top-image-3 {
   width: 100%;
 }
+
+#or-button-for-top-page:before {
+  background-color: whitesmoke;
+}

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -10,7 +10,6 @@ html
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
-    / pack_tagがwebpacker
     = stylesheet_pack_tag "application", media: "all", "data-turbolinks-track": "reload"
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
     / = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -13,7 +13,7 @@ header
         = f.button type: 'submit', class: "ui icon tiny button orange my-2 my-sm-0" do
           i.search.link.icon
       #search-by-picture-modal-button.nav-link.yubi.ui.orange.tiny.button
-        | 画像検索
+        | 食べ物を画像検索する
         i.camera.icon id='search-camera-icon'
       ul.navbar-nav.ml-auto.main-nav.align-items-rigiht
         li.nav-item

--- a/app/views/static_pages/top.html.slim
+++ b/app/views/static_pages/top.html.slim
@@ -4,16 +4,16 @@
 //////////////////////////////////////
 .ui.grid.computer.only.tablet.only.sixteen.wide#computer-top-page
   ///// ロゴ /////
-  .ui.stackable.very.relaxed.two.column.grid.container
+  .ui.stackable.very.relaxed.two.column.grid.container.pb-0
     .two.wide.column
     .left.aligned.ten.wide.column
       = image_pack_tag "media/images/zerorie_logo/zerorie_header_under_bar_transparent.png", id: 'top-image-1'
     .four.wide.column
   ///// 見出し /////
-  .ui.stackable.very.relaxed.two.column.grid.container
+  .ui.stackable.very.relaxed.two.column.grid.container.mt-0
     .two.wide.column
     .left.aligned.fourteen.wide.column
-      h1
+      h2.mb-4
         | その食べ物、ゼロカロリーです
       h4
         | 全ての食べ物を
@@ -24,7 +24,7 @@
       br
       .ui.buttons.mb-4
         = link_to t('.to_sign_up_page'), new_user_path, class: 'ui orange small button'
-        .or
+        .or#or-button-for-top-page
         = link_to t('.to_login_page'), login_path, method: :get, class: 'ui orange small button'
 
       br
@@ -86,12 +86,12 @@
 //////////////////////////////////////
 .ui.center.grid.mobile.only#tablet-mobile-top-page
   ///// ロゴ /////
-  .sixteen.wide.column
+  .sixteen.wide.column.pb-0
     = image_pack_tag "media/images/zerorie_logo/zerorie_header_under_bar_transparent.png", id: 'top-image-1'
   ///// 見出し /////
-  .sixteen.wide.column
+  .sixteen.wide.column.pt-0
     .ui.center.aligned.basic.segment
-      h1
+      h2.mb-4
         | その食べ物
         br
           | ゼロカロリーです
@@ -110,18 +110,18 @@
         = link_to t('defaults.guest_login'), guest_login_path, method: :post, class: 'ui yellow button'
   ///// 1つ目のブロック /////
   .sixteen.wide.column
-    .ui.center.aligned.basic.segment
+    .ui.center.aligned.basic.segment.mb-0.pb-0
       h2
         | 好きな食べ物を
         br
           | 好きなだけ食べる
-      p
+      p.mb-0.pb-0
         | Zerorieの世界では
         br
           | カロリーを気にして
           br
             | 食事を我慢する必要はありません
-    = image_pack_tag "media/images/top_page/zerorie_top_1.png", id: 'top-image-1'
+      = image_pack_tag "media/images/top_page/zerorie_top_1.png", id: 'top-image-1'
   ///// 2つ目のブロック /////
   .sixteen.wide.column
     .ui.center.aligned.basic.segment
@@ -129,13 +129,13 @@
         | 日々のカロリー
         br
           | 管理が不要
-      p
+      p.mb-0.pb-0
         | 1日の摂取カロリーを
         br
           | 計算する必要はありません
           br
             | そう、Zerorieならね
-    = image_pack_tag "media/images/top_page/zerorie_top_2.png", id: 'top-image-2'
+      = image_pack_tag "media/images/top_page/zerorie_top_2.png", id: 'top-image-2'
   ///// 3つ目のブロック /////
   .sixteen.wide.column
     .ui.center.aligned.basic.segment
@@ -143,10 +143,10 @@
         | 自分らしく自由に
         br
           | 食事を楽しむ
-      p
+      p.mb-0.pb-0
         | 1日に何度も訪れる食事の時間
         br
           | 自分の欲望に
           br
             | 素直になれる未来へ
-    = image_pack_tag "media/images/top_page/zerorie_top_3.png", id: 'top-image-3'
+      = image_pack_tag "media/images/top_page/zerorie_top_3.png", id: 'top-image-3'

--- a/config/asset_sync.yml
+++ b/config/asset_sync.yml
@@ -1,0 +1,32 @@
+defaults: &defaults
+  fog_provider: 'AWS'
+  aws_access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
+  aws_secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+  # To use AWS reduced redundancy storage.
+  # aws_reduced_redundancy: true
+  fog_directory: "zerorie" # バケット名を指定
+  # You may need to specify what region your storage bucket is in
+  fog_region: "ap-northeast-1"
+  existing_remote_files: keep
+  # To delete existing remote files.
+  # existing_remote_files: delete
+  # Automatically replace files with their equivalent gzip compressed version
+  # gzip_compression: true
+  # Fail silently.  Useful for environments such as Heroku
+  # fail_silently: true
+
+development:
+  <<: *defaults
+  enabled: false
+
+test:
+  <<: *defaults
+  enabled: false
+
+staging:
+  <<: *defaults
+  # fog_directory: "staging-hogehoge"
+
+production:
+  <<: *defaults
+  # fog_directory: "production-hogehoge"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.assets.compile = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
+  config.action_controller.asset_host = 'd2ou01vqsw9k6j.cloudfront.net'
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache


### PR DESCRIPTION
## 概要(なぜその変更を行ったか、どのような実装を加えたのか、などを記載)
トップページの読み込みが遅すぎるため、画像ファイルなどをクラウドに配置して、サーバへのリクエスト数を減らしたい。

## 追加した技術やGem
- gem 'asset_sync'
- gem 'fog-aws'

## 参考URL
- [Ruby on Rails + Assets on Cloud をCloudFront経由で高速化](https://qiita.com/kawasakiatsushi/items/208751ee1ad7255ac7bc)
- [[CloudFront + S3]特定バケットに特定ディストリビューションのみからアクセスできるよう設定する](https://dev.classmethod.jp/articles/cloudfront-s3-origin-access-identity/)
